### PR TITLE
Changed analysis log dumping -- now it is dumped for all dev documents in same file

### DIFF
--- a/tools/param_search.py
+++ b/tools/param_search.py
@@ -56,8 +56,11 @@ def get_evaluating_hook(
         classifier.save(model_path)
 
         if stats_generator is not None:
-            for i, doc in enumerate(dev_docs):
-                with open(join(stats_path, doc.name + '_stats.txt'), 'w', encoding='utf-8') as f:
+            with open(join(stats_path, 'dev_stats.txt'), 'w', encoding='utf-8') as f:
+                for i, doc in enumerate(dev_docs):
+                    f.write('#' * 80 + '\n')
+                    f.write(f"dev_doc_name = {doc.name}\n")
+                    f.write("-" * 80 + '\n')
                     f.write(stats_generator(i))
 
     def apply(classifier, epoch):


### PR DESCRIPTION
Before this MR we saved analysis stats for each dev document in separate file named after document. If document has long name this strategy will fail with `OSError`. Also this strategy is not good if we have many dev docs because they will be dumped as separate files in file directory.

Now i dump analysis of all dev docs in same file with some separators.