### PR TITLE
Bugfix -- it is now possible to provide entities types unseen in training set for relext classifier

### DIFF
--- a/derek/common/feature_extraction/ne_feature_extractor.py
+++ b/derek/common/feature_extraction/ne_feature_extractor.py
@@ -15,7 +15,8 @@ def generate_ne_feature_extractor(docs: Iterable[Document], props: dict):
         types = collect_entities_types(docs, extras=True)
         labelling_strategy = get_labelling_strategy(props.get("ne_labelling_strategy", "IO"))
         features['ne'] = {
-            'converter': create_categorical_converter(labelling_strategy.get_possible_categories(types), has_oov=True)
+            'converter': create_categorical_converter(labelling_strategy.get_possible_categories(types), has_oov=True,
+                                                      oov_object=labelling_strategy.outside_ent_label)
         }
         if props["ne_emb_size"] != 0:
             features["ne"]['embedding_size'] = props["ne_emb_size"]

--- a/derek/coref/feature_extraction/entity_feature_extractor.py
+++ b/derek/coref/feature_extraction/entity_feature_extractor.py
@@ -108,7 +108,7 @@ def _get_encoder_features(props, docs):
     encoder_features.update(
         create_feature('encoder_entity_ne', props,
                        create_categorical_converter(collect_entities_types(docs, extras=True).union('O'),
-                                                    zero_padding=True, has_oov=True)))
+                                                    zero_padding=True, has_oov=True, oov_object='O')))
 
     speech_types = props.get('speech_types', [])
     speech_size = props.get('speech_size', -1)

--- a/derek/coref/feature_extraction/factory.py
+++ b/derek/coref/feature_extraction/factory.py
@@ -93,7 +93,7 @@ def _get_classifier_features(props, docs):
 
     dual_features.update(
         create_feature('head_ne_types', props,
-                       create_categorical_converter(collect_entities_types(docs, extras=True).union('O'), has_oov=True)))
+                       create_categorical_converter(collect_entities_types(docs, extras=True).union('O'), has_oov=True, oov_object='O')))
 
     classifier_features.update(_get_binary_features(props))
 

--- a/derek/rel_ext/feature_extraction/factory.py
+++ b/derek/rel_ext/feature_extraction/factory.py
@@ -141,12 +141,13 @@ def _get_relation_level_features(props, rel_arg_types, entities_types, name_post
 
 
 def _get_entities_encoder_features(props, entities_types):
-    entities_types = entities_types.union({None})
+    oov_type = None
+    entities_types = entities_types.union({oov_type})
     features = {}
 
     if props.get("entities_types_emb_size", -1) >= 0:
         features['entities_types'] = {
-            'converter': create_categorical_converter(entities_types)
+            'converter': create_categorical_converter(entities_types, has_oov=True, oov_object=oov_type)
         }
         if props["entities_types_emb_size"] != 0:
             features["entities_types"]['embedding_size'] = props["entities_types_emb_size"]

--- a/tests/common/converters.py
+++ b/tests/common/converters.py
@@ -76,6 +76,39 @@ class TestCategoricalConverterClass(unittest.TestCase):
         self.assertEqual(indexed_categories, converter_indexed_categories)
         self.assertRaises(KeyError, getitem, converter, "$PADDING$")
 
+    def test_custom_oov_not_in_set(self):
+        categories_set = {"$HABITAT$", "$BACTERIA$", "hello", "laboratory"}
+        converter = create_categorical_converter(categories_set, zero_padding=False, has_oov=True, oov_object="$CUSTOM$")
+        indexed_categories = {
+            "$BACTERIA$": 0,
+            "$HABITAT$": 1,
+            "hello": 2,
+            "laboratory": 3,
+            "$CUSTOM$": 4,
+            '1': 4,
+            1: 4,
+            'privet': 4,
+        }
+
+        converter_indexed_categories = {key: converter[key] for key in indexed_categories}
+        self.assertEqual(indexed_categories, converter_indexed_categories)
+
+    def test_custom_oov_in_set(self):
+        categories_set = {"$HABITAT$", "$BACTERIA$", "hello", "laboratory"}
+        converter = create_categorical_converter(categories_set, zero_padding=False, has_oov=True, oov_object="hello")
+        indexed_categories = {
+            "$BACTERIA$": 0,
+            "$HABITAT$": 1,
+            "hello": 2,
+            "laboratory": 3,
+            '1': 2,
+            1: 2,
+            'privet': 2,
+        }
+
+        converter_indexed_categories = {key: converter[key] for key in indexed_categories}
+        self.assertEqual(indexed_categories, converter_indexed_categories)
+
 
 class TestUnsignedIntegerConverterClass(unittest.TestCase):
     def test_unsigned_integers_converter_1(self):


### PR DESCRIPTION
RelExt entities encoder converter had no OOV-label for unseen entity types. So it failed with `KeyError` when unseen entity type was provided during inference. 

Default `$OOV$` strategy was risky to use because no `$OOV$`-entities were provided during training so its embedding would be random at inference. So i added possibility to use custom oov-object in encoder to utilise no-entity category (`None`) for such cases.